### PR TITLE
feat: add support for typed arguments

### DIFF
--- a/src/parser/argument.ts
+++ b/src/parser/argument.ts
@@ -1,0 +1,40 @@
+import { TypeParser } from './type-parser';
+
+export interface ArgumentDefinition<T = unknown> {
+    parse: TypeParser<T>,
+    name?: string;
+    default?: T;
+    required?: boolean;
+}
+
+export type ArgumentDefinitionList = ArgumentDefinition[];
+
+/**
+ * ArgumentConfig is the configuration type derived from an ArgumentDefinitionList.
+ *
+ * @description
+ * The derived type is a mapped tuple type with the order of the original ArgumentDefinitionList,
+ * but the type of each tuple element is the value type `T` of the original ArgumentDefinition<T>.
+ */
+export type ArgumentConfig<T extends ArgumentDefinitionList> = {
+    [P in keyof T]: T[P] extends ArgumentDefinition<infer R> ? R : unknown;
+};
+
+export interface Argument<T = unknown> extends ArgumentDefinition<T> {
+    value?: T;
+}
+
+/**
+ * A helper function that infers the type of the created ArgumentDefinitionList and provides editor
+ * support (code completion) without having to explicitly declare the type of the ArgumentDefinitionList.
+ *
+ * @remarks
+ * By providing each argument definition as deparate argument, TypeScript can infer a mapped tuple type
+ * and preserve the inferred type of each ArgumentDefinition and its position in the tuple.
+ *
+ * @param args - The argument definitions
+ */
+export const args = <T extends ArgumentDefinitionList> (...args: T): T => {
+
+    return args;
+};

--- a/src/parser/commands/help/help.ts
+++ b/src/parser/commands/help/help.ts
@@ -1,4 +1,5 @@
 import { coerceArray } from '../../../utils';
+import { ArgumentDefinitionList } from '../../argument';
 import { command, CommandHandler, CommandType, HELP_COMMAND_NAME } from '../../command';
 import { LONG_FLAG_PREFIX, SHORT_FLAG_PREFIX } from '../../flag';
 import { Option, OptionDefinitionList } from '../../option';
@@ -23,7 +24,7 @@ export const formatOption = (option: Option): string | undefined => {
     return format;
 };
 
-export const HELP: CommandHandler<OptionDefinitionList> = (parser) => {
+export const HELP: CommandHandler<OptionDefinitionList, ArgumentDefinitionList> = (parser) => {
 
     const program = '<program>';
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,5 +1,6 @@
 export * from './type-parser';
 export * from './flag';
+export * from './argument';
 export * from './option';
 export * from './command';
 export * from './parser';

--- a/src/parser/option.ts
+++ b/src/parser/option.ts
@@ -16,6 +16,17 @@ export interface OptionDefinitionList {
     [key: string]: OptionDefinition;
 }
 
+/**
+ * OptionConfig is the configuration type derived from an OptionDefinitionList.
+ *
+ * @description
+ * The derived type is a mapped object type with the keys of the original OptionDefinitionList,
+ * but the type of each key is the value type `T` of the original OptionDefinition<T>.
+ */
+export type OptionConfig<O extends OptionDefinitionList> = {
+    [P in keyof O]: O[P] extends OptionDefinition<infer R> ? R : unknown;
+};
+
 export interface Option<T = unknown> extends OptionDefinition<T> {
     name: string;
     value?: T;
@@ -27,7 +38,7 @@ export interface Option<T = unknown> extends OptionDefinition<T> {
  *
  * @param options - The option definition list object
  */
-export function options<T extends OptionDefinitionList> (options: T): T {
+export function opts<T extends OptionDefinitionList> (options: T): T {
 
     return { ...options };
 }

--- a/test/commands/echo/config.ts
+++ b/test/commands/echo/config.ts
@@ -1,7 +1,7 @@
-import { BOOLEAN, options } from '../../../src';
+import { args, ARRAY, BOOLEAN, NUMBER, opts, STRING } from '../../../src';
 import { CLI_OPTIONS } from '../../config';
 
-export const ECHO_OPTIONS = options({
+export const ECHO_OPTIONS = opts({
     // we can inherit options from any other command - like here from the parent cli command
     ...CLI_OPTIONS,
     // and add or override custom options
@@ -21,3 +21,17 @@ export const ECHO_OPTIONS = options({
 
 // a helper type so we don't have to write `typeof ECHO_OPTIONS`
 export type EchoOptions = typeof ECHO_OPTIONS;
+
+export const ECHO_ARGUMENTS = args(
+    {
+        parse: ARRAY(STRING),
+        name: 'words',
+    },
+    {
+        parse: NUMBER,
+        name: 'which',
+    },
+);
+
+// a helper type so we don't have to write `typeof ECHO_ARGUMENTS`
+export type EchoArguments = typeof ECHO_ARGUMENTS;

--- a/test/commands/echo/echo.ts
+++ b/test/commands/echo/echo.ts
@@ -1,19 +1,21 @@
 import { CommandParser } from '../../../src';
-import { EchoOptions } from './config';
+import { EchoArguments, EchoOptions } from './config';
 
-export const ECHO = (parser: CommandParser<EchoOptions>): void => {
+export const ECHO = (parser: CommandParser<EchoOptions, EchoArguments>): void => {
 
     // the type of this config is inferred from the `EchoOptions` type
     const config = parser.config();
+    const [words, which] = parser.arguments();
 
     console.log(config);
+    console.log(parser.arguments());
 
     if (config.verbose) {
 
         console.log('about to echo...');
     }
 
-    let echo = config.foo;
+    let echo = words?.length ? words[which ?? 0] : config.foo;
 
     if (config.silent) {
 

--- a/test/commands/echo/index.ts
+++ b/test/commands/echo/index.ts
@@ -1,10 +1,11 @@
 import { command, CommandType } from '../../../src';
-import { ECHO_OPTIONS } from './config';
+import { ECHO_ARGUMENTS, ECHO_OPTIONS } from './config';
 import { ECHO } from './echo';
 
 export const ECHO_COMMAND = command({
     type: CommandType.ISOLATED,
     handler: ECHO,
+    arguments: ECHO_ARGUMENTS,
     options: ECHO_OPTIONS,
     // disable `help` and `version` commands for the echo command
     commands: {

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,6 +1,6 @@
-import { ARRAY, BOOLEAN, CommandConfig, NUMBER, options, STRING } from '../src';
+import { ARRAY, BOOLEAN, OptionConfig, NUMBER, opts, STRING } from '../src';
 
-export const CLI_OPTIONS = options({
+export const CLI_OPTIONS = opts({
     foo: {
         parse: STRING,
         default: 'foobar',
@@ -34,4 +34,4 @@ export const CLI_OPTIONS = options({
 export type CliOptions = typeof CLI_OPTIONS;
 
 // a helper type so we don't have to write `CommandConfig<CliOptions>`
-export type CliConfig = CommandConfig<CliOptions>;
+export type CliConfig = OptionConfig<CliOptions>;


### PR DESCRIPTION
a `CommandDefinition` can now have an `arguments` property which is a tuple of `ArgumentDefinition`s; `ArgumentDefinition`s have a `TypeParser`, name, default value, and required flag; arguments will be parsed in the same order as defined in the tuple