### PR TITLE
fix: validate cli input

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "process"
   ],
   "author": "Alexander Wende",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "@partkit/eslint-config": "^0.1.3",
     "@types/node": "^14.14.6",

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -30,8 +30,17 @@ export const INVALID_COMMAND = (command: string, parent?: string): ParserError =
         ? `sub-command of '${ parent }'`
         : 'command' }.`);
 
+export const INVALID_ARGUMENT = (argument: string, command: string): ParserError =>
+    new ParserError(`Invalid argument. '${ argument }' is not a valid argument of command '${ command }'.`);
+
 export const INVALID_OPTION = (option: string, command: string): ParserError =>
     new ParserError(`Invalid option. '${ option }' is not a valid option of command '${ command }'.`);
+
+export const MISSING_ARGUMENT = (argument: string[], command: string): ParserError =>
+    new ParserError(`Missing arguments. ${ argument.map(val => `'${ val }'`).join(', ') } ${ argument.length ? 'are required arguments' : 'is a required argument' } of command '${ command }'.`);
+
+export const MISSING_OPTION = (option: string[], command: string): ParserError =>
+    new ParserError(`Missing options. ${ option.map(val => `'${ val }'`).join(', ') } ${ option.length ? 'are required options' : 'is a required option' } of command '${ command }'.`);
 
 export const INVALID_USAGE = <T extends OptionDefinitionList> (parser: CommandParser<T>, api: string): UsageError =>
     new UsageError(`Invalid usage. Make sure to call '${ parser.constructor.name }.run()' before calling '${ parser.constructor.name }.${ api }()'.`);

--- a/src/parser/type-parser.ts
+++ b/src/parser/type-parser.ts
@@ -28,17 +28,17 @@ export const BOOLEAN = createTypeParser<boolean>(
     'boolean',
 );
 
-export const ARRAY = <T extends unknown> (parser: TypeParser<T>): TypeParser<Exclude<T, undefined>[]> => {
+export const ARRAY = <T extends unknown> (parser: TypeParser<T>, separator = ','): TypeParser<Exclude<T, undefined>[]> => {
 
     return createTypeParser<Exclude<T, undefined>[]>(
         (value) => {
 
             return isEmpty(value)
                 ? undefined
-                : value.split(',')
+                : value.split(separator)
                     .map(val => parser(val))
                     .filter(val => val !== undefined) as Exclude<T, undefined>[];
         },
-        `${ parser.hint }[]`,
+        `${ parser.hint }${ separator }...`,
     );
 };

--- a/test/commands/echo/index.ts
+++ b/test/commands/echo/index.ts
@@ -7,9 +7,8 @@ export const ECHO_COMMAND = command({
     handler: ECHO,
     arguments: ECHO_ARGUMENTS,
     options: ECHO_OPTIONS,
-    // disable `help` and `version` commands for the echo command
+    // disable `version` commands for the echo command
     commands: {
-        help: null,
         version: null,
     },
     name: 'echo',


### PR DESCRIPTION
- handle required arguments and options
- ignore option values following negated flags
- allow custom separator for ARRAY type parser